### PR TITLE
Fix #44, SIGTERM is not properly handled.

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -83,7 +83,7 @@ function init_non_systemd()
 		fi
 		"$CMD" "$@" &
 		pid=$!
-		fg > /dev/null
+		wait "$pid"
 	else
 		echo "Command not found: $1"
 		exit 1


### PR DESCRIPTION
The current entryscript can not trap the stop signal from Docker if we use `fg` command to wait for the background process to finish. So we should use `wait` command instead to trap and handle the stop signal properly.