### PR TITLE
Remove obsolete repository sources.

### DIFF
--- a/mkimage/debootstrap
+++ b/mkimage/debootstrap
@@ -203,9 +203,10 @@ fi
 	# delete all the apt list files since they're big and get stale quickly
 	rm -rf "$rootfsDir/var/lib/apt/lists"/*
 	# this forces "apt-get update" in dependent images, which is also good
-	echo "deb http://resin-packages.s3-website-us-east-1.amazonaws.com/raspbian resin main" >> "$rootfsDir/etc/apt/sources.list.d/resin.list"
-	chroot "$rootfsDir" bash -c 'sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 0x4404DDEE92BF1079'
-	echo "deb http://archive.raspberrypi.org/debian $suite main" >>  "$rootfsDir/etc/apt/sources.list.d/raspi.list"
-	chroot "$rootfsDir" bash -c 'sudo apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E'
+	if [ $suite != 'stretch' ]; then
+		# Raspberry PI Org doesn't have stretch yet.
+		echo "deb http://archive.raspberrypi.org/debian $suite main" >>  "$rootfsDir/etc/apt/sources.list.d/raspi.list"
+		chroot "$rootfsDir" bash -c 'sudo apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E'
+	fi
 	mkdir "$rootfsDir/var/lib/apt/lists/partial" # Lucid... "E: Lists directory /var/lib/apt/lists/partial is missing."
 )


### PR DESCRIPTION
We should keep the master Raspbian repository only, the same as official
raspbian image. Also resin repository can be retired since our patch was
merged into the official repo.