### PR TITLE
fix incorrect uname information

### DIFF
--- a/entry-nosystemd.sh
+++ b/entry-nosystemd.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-function remove_buildtime_env_var()
-{
-	unset QEMU_CPU
-}
-
 # On ResinOS 2.x devices, the hostname is set by the hostOS.
 # For backward compatibility, we only update the hostname for ResinOS 1.x devices.
 function update_hostname()
@@ -56,8 +51,6 @@ function init_non_systemd()
 		exit 1
 	fi
 }
-
-remove_buildtime_env_var
 
 INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
 

--- a/entry.sh
+++ b/entry.sh
@@ -8,11 +8,6 @@ function start_udev()
 	udevadm trigger &> /dev/null
 }
 
-function remove_buildtime_env_var()
-{
-	unset QEMU_CPU
-}
-
 # Send SIGTERM to child processes of PID 1.
 function signal_handler()
 {
@@ -96,8 +91,6 @@ function init_non_systemd()
 		exit 1
 	fi
 }
-
-remove_buildtime_env_var
 
 INITSYSTEM=$(echo "$INITSYSTEM" | awk '{print tolower($0)}')
 


### PR DESCRIPTION
According to the document https://docs.resin.io/runtime/resin-base-images/
`resin/rpi-raspbian` is built for armv6hf architecture.

However, when running `uname -m` inside the docker container, it reports
`armv7l`.

This is because `QEMU_CPU` is incorrectly removed inside entry scripts.

Fix it by persevering `QEMU_CPU` variable.