### PR TITLE
Change the service to restart on-failure only.

### DIFF
--- a/launch.service
+++ b/launch.service
@@ -7,7 +7,7 @@ ExecStart=/etc/resinApp.sh
 StandardOutput=tty
 StandardError=tty
 TTYPath=/dev/console
-Restart=always
+Restart=on-failure
 
 
 [Install]


### PR DESCRIPTION
`Always` will restart the service whether it exited cleanly or not which is not good.

Connects to https://github.com/resin-io-library/base-images/pull/364