### PR TITLE
Add support for Raspbian Buster

### DIFF
--- a/01_buildconfig
+++ b/01_buildconfig
@@ -1,5 +1,4 @@
 APT::Get::Assume-Yes "true";
-APT::Get::force-yes "true";
 APT::Install-Recommends "0";
 APT::Install-Suggests "0";
 quiet "true";

--- a/Dockerfile.systemd
+++ b/Dockerfile.systemd
@@ -29,6 +29,12 @@ LABEL io.resin.architecture="rpi" \
 ENV QEMU_CPU arm1176
 
 # Install Systemd
+
+RUN apt-get update && apt-get install --no-install-recommends \
+        systemd \
+        systemd-sysv \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV container docker
 
 # We never want these to run in a container

--- a/automation/jenkins-build.sh
+++ b/automation/jenkins-build.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-export SUITES='wheezy jessie stretch'
+export SUITES='wheezy jessie stretch buster'
 export REPO='resin/rpi-raspbian'
 ALIAS_REPO='resin/raspberry-pi-debian'
 LATEST='jessie'

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -86,15 +86,18 @@ touch "$tarFile"
 	tar --numeric-owner -caf "$tarFile" -C "$rootfsDir" --transform='s,^./,,' .
 )
 
-cp -f 01_nodoc 01_buildconfig resin-pinning "$dir/"
+cp -f 01_nodoc resin-pinning 01_buildconfig "$dir/"
 
-if [ $SUITE == 'wheezy' ]; then
+case "$SUITE" in
+'wheezy')
 	mv Dockerfile.no-systemd "$dir/Dockerfile"
 	cp entry-nosystemd.sh "$dir/entry.sh"
-else
+;;
+*) # jessie stretch buster
 	mv Dockerfile.systemd "$dir/Dockerfile"
 	cp entry.sh launch.service "$dir/"
-fi
+;;
+esac
 
 # if our generated image has a decent shell, let's set a default command
 for shell in /bin/bash /usr/bin/fish /usr/bin/zsh /bin/sh; do

--- a/mkimage/debootstrap
+++ b/mkimage/debootstrap
@@ -203,8 +203,8 @@ fi
 	# delete all the apt list files since they're big and get stale quickly
 	rm -rf "$rootfsDir/var/lib/apt/lists"/*
 	# this forces "apt-get update" in dependent images, which is also good
-	if [ $suite != 'stretch' ]; then
-		# Raspberry PI Org doesn't have stretch yet.
+	if [ $suite != 'buster' ]; then
+		# Raspberry PI Org doesn't have buster yet.
 		echo "deb http://archive.raspberrypi.org/debian $suite main" >>  "$rootfsDir/etc/apt/sources.list.d/raspi.list"
 		chroot "$rootfsDir" bash -c 'sudo apt-key adv --keyserver pgp.mit.edu  --recv-key 0x82B129927FA3303E'
 	fi


### PR DESCRIPTION
Note: apt `force-yes` option is replaced since it's deprecated.