### PR TITLE
systemd: Fix missing env vars inside web terminal when systemd enabled

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -76,6 +76,7 @@ function init_systemd()
 	for var in $(compgen -e); do
 		printf '%q="%q"\n' "$var" "${!var}"
 	done > /etc/docker.env
+	echo 'source /etc/docker.env' >> ~/.bashrc
 
 	printf '#!/bin/bash\n exec ' > /etc/resinApp.sh
 	printf '%q ' "$@" >> /etc/resinApp.sh


### PR DESCRIPTION
Connects to https://github.com/resin-io-library/base-images/pull/473